### PR TITLE
Set correct height validators were taken from

### DIFF
--- a/node/remote/node.go
+++ b/node/remote/node.go
@@ -184,6 +184,7 @@ func (cp *Node) Validators(height int64) (*tmctypes.ResultValidators, error) {
 		vals.Validators = append(vals.Validators, result.Validators...)
 		vals.Count += result.Count
 		vals.Total = result.Total
+		vals.BlockHeight = result.BlockHeight
 		page++
 		stop = vals.Count == vals.Total
 	}


### PR DESCRIPTION
I expect that it is not guaranteed that data for requested height are available (pruning). I guess in that case API returns data for the highest previous height available. That's why height should be set to the one returned from the API.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/CoreumFoundation/junov5/2)
<!-- Reviewable:end -->
